### PR TITLE
Automatically comment on CODEOWNERS Pull Requests

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -12,17 +12,10 @@ env:
   CODEOWNERS_COMMENT: |
     Release Engineering asks that teams use the following process for routine reviews:
 
-    1. After creating a non-draft pull request that includes automation updates,
-       a release engineer will be auto-assigned to the PR.
-    2. When dev review is complete and the PR is ready for the release engineer
-       to review, add a "ready for RE review" label to the PR to let us know when
-       the PR is ready for us to review.
-    3. If you've added the "ready for RE review" label but haven't received a
-       review within a 36 hours, @-mention the assigned RE in a comment on the PR.
-    4. If you don't receive a response from the assigned RE by the end of the
-       next business day (or your request is urgent), post a message to
-       #sfdo-releng-support that includes a link to this PR and one of us will
-       review as soon as we're able.
+    1. After creating a non-draft pull request that includes automation updates, a release engineer will be auto-assigned to the PR.
+    2. When dev review is complete and the PR is ready for the release engineer to review, add a "ready for RE review" label to the PR to let us know when the PR is ready for us to review.
+    3. If you've added the "ready for RE review" label but haven't received a review within a 36 hours, @-mention the assigned RE in a comment on the PR.
+    4. If you don't receive a response from the assigned RE by the end of the next business day (or your request is urgent), post a message to #sfdo-releng-support that includes a link to this PR and one of us will review as soon as we're able.
 
 jobs:
   codeowners_workflow_comments:

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -10,7 +10,7 @@ env:
   READY_FOR_REVIEW_COMMENT: |
     This PR has been labeled as ready for Release Engineering review by
   CODEOWNERS_COMMENT: |
-    We ask that teams use the following process for routine reviews:
+    Release Engineering asks that teams use the following process for routine reviews:
 
     1. After creating a non-draft pull request that includes automation updates,
        a release engineer will be auto-assigned to the PR.
@@ -41,7 +41,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `👋 @${context.payload.pull_request.user.login}${comment_body}`
+              body: `Hi 👋 @${context.payload.pull_request.user.login}! ${comment_body}`
             })
       - name: Labeled ready for CODEOWNERS Review
         id: codeowners-labeled-ready

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,0 +1,90 @@
+name: SFDO Codeowners Review Workflows
+on:
+  pull_request:
+    types:
+      - labeled
+      - review_requested
+
+env:
+  CODEOWNERS_TEAM: 'salesforce-org-release-engineering'
+  READY_FOR_REVIEW_COMMENT: |
+    has labeled as ready for Release Engineering review.
+
+  CODEOWNERS_COMMENT: |
+    We ask that teams use the following process for routine reviews:
+
+    1. After creating a non-draft pull request that includes automation updates,
+       a release engineer will be auto-assigned to the PR.
+    2. When dev review is complete and the PR is ready for the release engineer
+       to review, add a "ready for RE review" label to the PR to let us know when
+       the PR is ready for us to review.
+    3. If you've added the "ready for RE review" label but haven't received a
+       review within a 36 hours, @-mention the assigned RE in a comment on the PR.
+    4. If you don't receive a response from the assigned RE by the end of the
+       next business day (or your request is urgent), post a message to
+       #sfdo-releng-support that includes a link to this PR and one of us will
+       review as soon as we're able.
+
+jobs:
+  workflow_codeowners_comment:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'review_requested'
+    steps:
+      - name: Add comment
+        id: codeowners-comment
+        if: github.event.requested_team.slug == 'salesforce-org-release-engineering'
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.CODEOWNERS_COMMENT
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 @${context.payload.pull_request.user.login} ${comment_body}`
+            })
+  workflow_ready_comment:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
+    steps:
+      - name: Add comment
+        id: codeowners-comment
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
+            const review_team = process.env.CODEOWNERS_TEAM;
+
+            let team = github.teams
+              .listMembersInOrg({
+                org: context.repo.owner,
+                team_slug: review_team,
+                role: "all",
+              })
+              .map((_) => _.login);
+
+            let team_reviewers = github.pulls
+              .listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              })
+              .map((_) => _.login)
+              .filter((login) => team.includes(login));
+
+            let mention_text = '';
+            if (team_reviewers.length >= 1) {
+              let reviewer_mentions = team_reviewers
+                .map((login, idx) => `${idx}. @${login}`)
+                .join(', ');
+
+                mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
+            }
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 @${context.payload.sender.login} ${comment_body} ${mention_text}`,
+            });

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -6,10 +6,9 @@ on:
       - review_requested
 
 env:
-  CODEOWNERS_TEAM: 'salesforce-org-release-engineering'
+  CODEOWNERS_TEAM: 'release-engineering-reviewers'
   READY_FOR_REVIEW_COMMENT: |
-    has labeled as ready for Release Engineering review.
-
+    This PR has been labeled as ready for Release Engineering review by
   CODEOWNERS_COMMENT: |
     We ask that teams use the following process for routine reviews:
 
@@ -26,34 +25,14 @@ env:
        review as soon as we're able.
 
 jobs:
-  workflow_codeowners_comment:
+  codeowners_workflow_comments:
     runs-on: ubuntu-latest
-    if: github.event.action == 'review_requested'
     steps:
-      - name: Add comment
-        id: codeowners-comment
-        if: github.event.requested_team.slug == 'salesforce-org-release-engineering'
+      - name: Query for reviewers
+        id: codeowners-team-members
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
-            const comment_body = process.env.CODEOWNERS_COMMENT
-
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `👋 @${context.payload.pull_request.user.login} ${comment_body}`
-            })
-  workflow_ready_comment:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
-    steps:
-      - name: Add comment
-        id: codeowners-comment
-        uses: SalesforceFoundation/github-script@v4
-        with:
-          script: |
-            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
             const review_team = process.env.CODEOWNERS_TEAM;
 
             let team = github.teams
@@ -64,7 +43,7 @@ jobs:
               })
               .map((_) => _.login);
 
-            let team_reviewers = github.pulls
+            let review_team_members = github.pulls
               .listRequestedReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -73,12 +52,49 @@ jobs:
               .map((_) => _.login)
               .filter((login) => team.includes(login));
 
-            let mention_text = '';
-            if (team_reviewers.length >= 1) {
-              let reviewer_mentions = team_reviewers
-                .map((login, idx) => `${idx}. @${login}`)
-                .join(', ');
+            return review_team_members;
 
+      - name: CODEOWNERS Review Requested
+        id: codeowners-comment
+        if: github.event.action == 'review_requested' &&
+            github.event.requested_team.slug == env.CODEOWNERS_team ||
+            contains(fromJSON(steps.codeowners-team-members.result), github.event.requested_reviewer.login)
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.CODEOWNERS_COMMENT
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 @${context.payload.pull_request.user.login}${comment_body}`
+            })
+      - name: Labeled ready for CODEOWNERS Review
+        id: codeowners-labeled-ready
+        if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
+            let mention_text = '';
+
+            let team_reviewers = ${{ fromJSON(steps.codeowners-team-members.result) }}
+            let requested_team_reviewers = github.event.pull_request.requested_reviewers
+              .map((_) => _.login)
+              .filter((login) => team_reviewers.includes(login))
+
+            if (requested_team_reviewers.length >= 1) {
+              github.issues.addAssignees({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignees: requested_team_reviewers,
+              });
+
+              let reviewer_mentions = team_reviewers
+                .map((login) => `@${login}`)
+                .join(', ');
                 mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
             }
 
@@ -86,5 +102,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `👋 @${context.payload.sender.login} ${comment_body} ${mention_text}`,
+              body: `${comment_body} @${context.payload.sender.login} ${mention_text}`,
             });

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -49,10 +49,10 @@ jobs:
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
-            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
+            const comment_body = process.env.READY_FOR_REVIEW_COMMENT
             let mention_text = '';
 
-            let requested_reviewers = github.event.pull_request.requested_reviewers
+            let requested_reviewers = context.payload.pull_request.requested_reviewers
               .map((_) => _.login)
 
             if (requested_reviewers.length >= 1) {

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -46,7 +46,7 @@ jobs:
             let mention_text = '';
 
             let requested_reviewers = context.payload.pull_request.requested_reviewers
-              .map((_) => _.login)
+              .map((reviewer) => reviewer.login)
 
             if (requested_reviewers.length >= 1) {
               let reviewer_mentions = requested_reviewers
@@ -59,5 +59,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${comment_body} @${context.payload.sender.login} ${mention_text}`,
+              body: `${comment_body} @${context.payload.sender.login}. ${mention_text}`,
             });

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -28,37 +28,10 @@ jobs:
   codeowners_workflow_comments:
     runs-on: ubuntu-latest
     steps:
-      - name: Query for reviewers
-        id: codeowners-team-members
-        uses: SalesforceFoundation/github-script@v4
-        with:
-          script: |
-            const review_team = process.env.CODEOWNERS_TEAM;
-
-            let team = github.teams
-              .listMembersInOrg({
-                org: context.repo.owner,
-                team_slug: review_team,
-                role: "all",
-              })
-              .map((_) => _.login);
-
-            let review_team_members = github.pulls
-              .listRequestedReviewers({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-              })
-              .map((_) => _.login)
-              .filter((login) => team.includes(login));
-
-            return review_team_members;
-
       - name: CODEOWNERS Review Requested
         id: codeowners-comment
         if: github.event.action == 'review_requested' &&
-            github.event.requested_team.slug == env.CODEOWNERS_team ||
-            contains(fromJSON(steps.codeowners-team-members.result), github.event.requested_reviewer.login)
+            github.event.requested_team.slug == env.CODEOWNERS_team
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
@@ -79,20 +52,11 @@ jobs:
             const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
             let mention_text = '';
 
-            let team_reviewers = ${{ fromJSON(steps.codeowners-team-members.result) }}
-            let requested_team_reviewers = github.event.pull_request.requested_reviewers
+            let requested_reviewers = github.event.pull_request.requested_reviewers
               .map((_) => _.login)
-              .filter((login) => team_reviewers.includes(login))
 
-            if (requested_team_reviewers.length >= 1) {
-              github.issues.addAssignees({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                assignees: requested_team_reviewers,
-              });
-
-              let reviewer_mentions = team_reviewers
+            if (requested_reviewers.length >= 1) {
+              let reviewer_mentions = requested_reviewers
                 .map((login) => `@${login}`)
                 .join(', ');
                 mention_text = `Reviews have been requested from: @${reviewer_mentions}.`

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -59,7 +59,7 @@ jobs:
               let reviewer_mentions = requested_reviewers
                 .map((login) => `@${login}`)
                 .join(', ');
-                mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
+                mention_text = `Reviews have been requested from: ${reviewer_mentions}.`
             }
 
             github.issues.createComment({

--- a/workflow-templates/codeowners.properties.json
+++ b/workflow-templates/codeowners.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "SFDO Codeowners Review Workflows",
+    "description": "Housekeeping scripts for automated pull request workflows.",
+    "iconName": "sfdo",
+    "filePatterns": [
+        "CODEOWNERS$"
+    ]
+}

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -12,17 +12,10 @@ env:
   CODEOWNERS_COMMENT: |
     Release Engineering asks that teams use the following process for routine reviews:
 
-    1. After creating a non-draft pull request that includes automation updates,
-       a release engineer will be auto-assigned to the PR.
-    2. When dev review is complete and the PR is ready for the release engineer
-       to review, add a "ready for RE review" label to the PR to let us know when
-       the PR is ready for us to review.
-    3. If you've added the "ready for RE review" label but haven't received a
-       review within a 36 hours, @-mention the assigned RE in a comment on the PR.
-    4. If you don't receive a response from the assigned RE by the end of the
-       next business day (or your request is urgent), post a message to
-       #sfdo-releng-support that includes a link to this PR and one of us will
-       review as soon as we're able.
+    1. After creating a non-draft pull request that includes automation updates, a release engineer will be auto-assigned to the PR.
+    2. When dev review is complete and the PR is ready for the release engineer to review, add a "ready for RE review" label to the PR to let us know when the PR is ready for us to review.
+    3. If you've added the "ready for RE review" label but haven't received a review within a 36 hours, @-mention the assigned RE in a comment on the PR.
+    4. If you don't receive a response from the assigned RE by the end of the next business day (or your request is urgent), post a message to #sfdo-releng-support that includes a link to this PR and one of us will review as soon as we're able.
 
 jobs:
   codeowners_workflow_comments:

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -10,7 +10,7 @@ env:
   READY_FOR_REVIEW_COMMENT: |
     This PR has been labeled as ready for Release Engineering review by
   CODEOWNERS_COMMENT: |
-    We ask that teams use the following process for routine reviews:
+    Release Engineering asks that teams use the following process for routine reviews:
 
     1. After creating a non-draft pull request that includes automation updates,
        a release engineer will be auto-assigned to the PR.
@@ -41,7 +41,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `👋 @${context.payload.pull_request.user.login}${comment_body}`
+              body: `Hi 👋 @${context.payload.pull_request.user.login}! ${comment_body}`
             })
       - name: Labeled ready for CODEOWNERS Review
         id: codeowners-labeled-ready

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -1,0 +1,90 @@
+name: SFDO Codeowners Review Workflows
+on:
+  pull_request:
+    types:
+      - labeled
+      - review_requested
+
+env:
+  CODEOWNERS_TEAM: 'salesforce-org-release-engineering'
+  READY_FOR_REVIEW_COMMENT: |
+    has labeled as ready for Release Engineering review.
+
+  CODEOWNERS_COMMENT: |
+    We ask that teams use the following process for routine reviews:
+
+    1. After creating a non-draft pull request that includes automation updates,
+       a release engineer will be auto-assigned to the PR.
+    2. When dev review is complete and the PR is ready for the release engineer
+       to review, add a "ready for RE review" label to the PR to let us know when
+       the PR is ready for us to review.
+    3. If you've added the "ready for RE review" label but haven't received a
+       review within a 36 hours, @-mention the assigned RE in a comment on the PR.
+    4. If you don't receive a response from the assigned RE by the end of the
+       next business day (or your request is urgent), post a message to
+       #sfdo-releng-support that includes a link to this PR and one of us will
+       review as soon as we're able.
+
+jobs:
+  workflow_codeowners_comment:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'review_requested'
+    steps:
+      - name: Add comment
+        id: codeowners-comment
+        if: github.event.requested_team.slug == 'salesforce-org-release-engineering'
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.CODEOWNERS_COMMENT
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 @${context.payload.pull_request.user.login} ${comment_body}`
+            })
+  workflow_ready_comment:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
+    steps:
+      - name: Add comment
+        id: codeowners-comment
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
+            const review_team = process.env.CODEOWNERS_TEAM;
+
+            let team = github.teams
+              .listMembersInOrg({
+                org: context.repo.owner,
+                team_slug: review_team,
+                role: "all",
+              })
+              .map((_) => _.login);
+
+            let team_reviewers = github.pulls
+              .listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+              })
+              .map((_) => _.login)
+              .filter((login) => team.includes(login));
+
+            let mention_text = '';
+            if (team_reviewers.length >= 1) {
+              let reviewer_mentions = team_reviewers
+                .map((login, idx) => `${idx}. @${login}`)
+                .join(', ');
+
+                mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
+            }
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `👋 @${context.payload.sender.login} ${comment_body} ${mention_text}`,
+            });

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -28,39 +28,10 @@ jobs:
   codeowners_workflow_comments:
     runs-on: ubuntu-latest
     steps:
-      - name: Query for reviewers
-        id: codeowners-team-members
-        uses: SalesforceFoundation/github-script@v4
-        with:
-          script: |
-            const review_team = process.env.CODEOWNERS_TEAM;
-
-            const query = `query ($org: String!, $slug: String!) {
-              organization(login: $org) {
-                team(slug: $slug) {
-                  members {
-                    nodes {
-                      login
-                    }
-                  }
-                }
-              }
-            }`;
-
-            const variables = {
-              org: context.repo.owner,
-              slug: process.env.CODEOWNERS_TEAM
-            }
-
-            const result = await github.graphql(query, variables)
-            review_team_members = result.organization.team.members.nodes
-              .map((_) => _.login)
-            return review_team_members
       - name: CODEOWNERS Review Requested
         id: codeowners-comment
         if: github.event.action == 'review_requested' &&
-            github.event.requested_team.slug == env.CODEOWNERS_team ||
-            contains(fromJSON(steps.codeowners-team-members.result), github.event.requested_reviewer.login)
+            github.event.requested_team.slug == env.CODEOWNERS_team
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
@@ -81,20 +52,11 @@ jobs:
             const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
             let mention_text = '';
 
-            let team_reviewers = ${{ fromJSON(steps.codeowners-team-members.result) }}
-            let requested_team_reviewers = github.event.pull_request.requested_reviewers
+            let requested_reviewers = github.event.pull_request.requested_reviewers
               .map((_) => _.login)
-              .filter((login) => team_reviewers.includes(login))
 
-            if (requested_team_reviewers.length >= 1) {
-              github.issues.addAssignees({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                assignees: requested_team_reviewers,
-              });
-
-              let reviewer_mentions = team_reviewers
+            if (requested_reviewers.length >= 1) {
+              let reviewer_mentions = requested_reviewers
                 .map((login) => `@${login}`)
                 .join(', ');
                 mention_text = `Reviews have been requested from: @${reviewer_mentions}.`

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -49,7 +49,7 @@ jobs:
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
-            const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
+            const comment_body = process.env.READY_FOR_REVIEW_COMMENT
             let mention_text = '';
 
             let requested_reviewers = github.event.pull_request.requested_reviewers

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -46,7 +46,7 @@ jobs:
             let mention_text = '';
 
             let requested_reviewers = context.payload.pull_request.requested_reviewers
-              .map((_) => _.login)
+              .map((reviewer) => reviewer.login)
 
             if (requested_reviewers.length >= 1) {
               let reviewer_mentions = requested_reviewers
@@ -59,5 +59,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${comment_body} @${context.payload.sender.login} ${mention_text}`,
+              body: `${comment_body} @${context.payload.sender.login}. ${mention_text}`,
             });

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -52,14 +52,14 @@ jobs:
             const comment_body = process.env.READY_FOR_REVIEW_COMMENT
             let mention_text = '';
 
-            let requested_reviewers = github.event.pull_request.requested_reviewers
+            let requested_reviewers = context.payload.pull_request.requested_reviewers
               .map((_) => _.login)
 
             if (requested_reviewers.length >= 1) {
               let reviewer_mentions = requested_reviewers
                 .map((login) => `@${login}`)
                 .join(', ');
-                mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
+                mention_text = `Reviews have been requested from: ${reviewer_mentions}.`
             }
 
             github.issues.createComment({

--- a/workflow-templates/codeowners.yml
+++ b/workflow-templates/codeowners.yml
@@ -6,10 +6,9 @@ on:
       - review_requested
 
 env:
-  CODEOWNERS_TEAM: 'salesforce-org-release-engineering'
+  CODEOWNERS_TEAM: 'release-engineering-reviewers'
   READY_FOR_REVIEW_COMMENT: |
-    has labeled as ready for Release Engineering review.
-
+    This PR has been labeled as ready for Release Engineering review by
   CODEOWNERS_COMMENT: |
     We ask that teams use the following process for routine reviews:
 
@@ -26,13 +25,42 @@ env:
        review as soon as we're able.
 
 jobs:
-  workflow_codeowners_comment:
+  codeowners_workflow_comments:
     runs-on: ubuntu-latest
-    if: github.event.action == 'review_requested'
     steps:
-      - name: Add comment
+      - name: Query for reviewers
+        id: codeowners-team-members
+        uses: SalesforceFoundation/github-script@v4
+        with:
+          script: |
+            const review_team = process.env.CODEOWNERS_TEAM;
+
+            const query = `query ($org: String!, $slug: String!) {
+              organization(login: $org) {
+                team(slug: $slug) {
+                  members {
+                    nodes {
+                      login
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const variables = {
+              org: context.repo.owner,
+              slug: process.env.CODEOWNERS_TEAM
+            }
+
+            const result = await github.graphql(query, variables)
+            review_team_members = result.organization.team.members.nodes
+              .map((_) => _.login)
+            return review_team_members
+      - name: CODEOWNERS Review Requested
         id: codeowners-comment
-        if: github.event.requested_team.slug == 'salesforce-org-release-engineering'
+        if: github.event.action == 'review_requested' &&
+            github.event.requested_team.slug == env.CODEOWNERS_team ||
+            contains(fromJSON(steps.codeowners-team-members.result), github.event.requested_reviewer.login)
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
@@ -42,43 +70,33 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `👋 @${context.payload.pull_request.user.login} ${comment_body}`
+              body: `👋 @${context.payload.pull_request.user.login}${comment_body}`
             })
-  workflow_ready_comment:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
-    steps:
-      - name: Add comment
-        id: codeowners-comment
+      - name: Labeled ready for CODEOWNERS Review
+        id: codeowners-labeled-ready
+        if: github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ready for RE review')
         uses: SalesforceFoundation/github-script@v4
         with:
           script: |
             const comment_body = process.env.READY_FOR_REVIEW_COMMENT:
-            const review_team = process.env.CODEOWNERS_TEAM;
+            let mention_text = '';
 
-            let team = github.teams
-              .listMembersInOrg({
-                org: context.repo.owner,
-                team_slug: review_team,
-                role: "all",
-              })
-              .map((_) => _.login);
+            let team_reviewers = ${{ fromJSON(steps.codeowners-team-members.result) }}
+            let requested_team_reviewers = github.event.pull_request.requested_reviewers
+              .map((_) => _.login)
+              .filter((login) => team_reviewers.includes(login))
 
-            let team_reviewers = github.pulls
-              .listRequestedReviewers({
+            if (requested_team_reviewers.length >= 1) {
+              github.issues.addAssignees({
+                issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-              })
-              .map((_) => _.login)
-              .filter((login) => team.includes(login));
+                assignees: requested_team_reviewers,
+              });
 
-            let mention_text = '';
-            if (team_reviewers.length >= 1) {
               let reviewer_mentions = team_reviewers
-                .map((login, idx) => `${idx}. @${login}`)
+                .map((login) => `@${login}`)
                 .join(', ');
-
                 mention_text = `Reviews have been requested from: @${reviewer_mentions}.`
             }
 
@@ -86,5 +104,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `👋 @${context.payload.sender.login} ${comment_body} ${mention_text}`,
+              body: `${comment_body} @${context.payload.sender.login} ${mention_text}`,
             });


### PR DESCRIPTION
This PR adds a new organization workflow utilizing the github-script
action that will add comments to PRs on the following events:

1. A review request (`pull_request.review_requested`) from a given
   CODEOWNERS github team (`release-engineering-reviewers`).
2. A user adds the "ready for RE review" label (`pull_request.review_requested`) to a pull request.